### PR TITLE
Update clemsonMakerspace Fork link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Penn State ACM Check-in
 #### Shane Tully (shane@shanetully.com)
 #### shanetully.com & acm.psu.edu
 
-**Note:** An actively maintained fork of this project exists at https://github.com/clemsonMakerspace/Magstripe_Attendance.
+**Note:** An actively maintained fork of this project exists at http://clemsonmakerspace.github.io/Magstripe_Attendance/.
 
 ### Dependencies
 


### PR DESCRIPTION
I've created a github.io page for the clemsonMakerspace fork of this project, and I would like to have the README link to that instead.
